### PR TITLE
fix(Makefile): add deploy-demo target missing from #7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ clean:
 
 test:
 	forge test
+
+deploy-demo:
+	./tools/deploy-demo.sh


### PR DESCRIPTION
## Summary
Adds the `make deploy-demo` target that was accidentally omitted from #7.

## Changes
- `Makefile`: adds `deploy-demo` target invoking `./tools/deploy-demo.sh`