### PR TITLE
feat: add FRC-0042 method constants and CBOR codec

### DIFF
--- a/src/FVMCodec.sol
+++ b/src/FVMCodec.sol
@@ -6,3 +6,6 @@ uint64 constant EMPTY_CODEC = 0;
 
 // @dev actor returned unencoded raw data
 uint64 constant RAW_CODEC = 0x55;
+
+// @dev CBOR encoded data (IPLD dag-cbor)
+uint64 constant CBOR_CODEC = 0x51;

--- a/src/FVMMethod.sol
+++ b/src/FVMMethod.sol
@@ -3,3 +3,11 @@ pragma solidity ^0.8.30;
 
 uint64 constant SEND = 0;
 uint64 constant CONSTRUCT = 1;
+
+// FRC-0042 hashed method numbers (https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md)
+uint64 constant AUTHENTICATE_MESSAGE = 2643134072;
+uint64 constant UNIVERSAL_RECEIVER_HOOK = 118350608;
+uint64 constant RECEIVE = 3726118371;
+uint64 constant MARKET_NOTIFY_DEAL = 4186741094;
+uint64 constant SECTOR_CONTENT_CHANGED = 2034386435;
+uint64 constant INVOKE_EVM = 3844450837;


### PR DESCRIPTION
## Changes
- `FVMMethod.sol`: add 6 FRC-0042 hashed method constants used in `handle_filecoin_method`
- `FVMCodec.sol`: add `CBOR_CODEC = 0x51`

## Method constants added
Found FRC-0042 usages in builtin-actors via: [builtin-actors source](https://github.com/search?q=repo%3Afilecoin-project%2Fbuiltin-actors%20frc42_dispatch&type=code)

Added only inbound callback methods (dispatched onto your contract by the FVM):
| Constant | Value |
|---|---|
| `AUTHENTICATE_MESSAGE` | 2643134072 |
| `UNIVERSAL_RECEIVER_HOOK` | 118350608 |
| `RECEIVE` | 3726118371 |
| `MARKET_NOTIFY_DEAL` | 4186741094 |
| `SECTOR_CONTENT_CHANGED` | 2034386435 |
| `INVOKE_EVM` | 3844450837 |

Skipped outbound actor call methods (market queries, miner admin, datacap/FRC-0046 token methods, power, verifreg) as those are a separate concern.

## Verification
Values verified via FRC-0042 spec using Python's stdlib `blake2b`:

```python

import hashlib

def frc42_hash(method_name: str) -> int:
    domain_tag = "1|"
    data = (domain_tag + method_name).encode()
    digest = list(hashlib.blake2b(data, digest_size=64).digest())
    while len(digest) >= 4:
        method_id = int.from_bytes(digest[0:4], 'big')
        if method_id >= (1 << 24):
            return method_id
        digest = digest[4:]
    raise Exception("Method ID could not be determined")
```

Closes #12 