### PR TITLE
fix: shadowed declarations

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,8 +11,7 @@ optimizer_runs = 200
 via_ir = true
 
 ignored_error_codes = [
-    2519, # shadowed declarations
-    3628, # https://github.com/argotorg/solidity/issues/10159
+    3628, # missing-receive-ether, see https://github.com/argotorg/solidity/issues/10159
 ]
 
 # For dependencies

--- a/src/FVMAddress.sol
+++ b/src/FVMAddress.sol
@@ -5,7 +5,8 @@ library FVMAddress {
     error NotMaskedIdAddress(address addr);
 
     /// @notice Creates an f0 (ID) address in bytes using unsigned LEB128 encoding
-    function f0(uint64 actorId) internal pure returns (bytes memory buffer) {
+    /// @param id Actor ID to encode
+    function f0(uint64 id) internal pure returns (bytes memory buffer) {
         // Max size: 1 protocol byte + 10 bytes for uint64 LEB128 encoding
         buffer = new bytes(11);
         buffer[0] = 0x00; // Protocol byte for f0
@@ -13,13 +14,13 @@ library FVMAddress {
         uint256 i = 1;
 
         do {
-            uint8 byteVal = uint8(actorId & 0x7F); // Take 7 bits
-            actorId >>= 7; // Shift right by 7 bits
-            if (actorId != 0) {
+            uint8 byteVal = uint8(id & 0x7F); // Take 7 bits
+            id >>= 7; // Shift right by 7 bits
+            if (id != 0) {
                 byteVal |= 0x80; // Set MSB if more bytes follow
             }
             buffer[i++] = bytes1(byteVal);
-        } while (actorId != 0);
+        } while (id != 0);
 
         assembly ("memory-safe") {
             mstore(buffer, i) // Set the correct length of the bytes array
@@ -39,9 +40,10 @@ library FVMAddress {
 
     /// @notice Creates a masked ID address (the EVM encoding of an f0 actor ID)
     /// @dev Format: 0xff + 11 zero bytes + big-endian uint64 actor ID (20 bytes total)
-    function maskedAddress(uint64 actorId) internal pure returns (address maskedAddr) {
+    /// @param id Actor ID to encode
+    function maskedAddress(uint64 id) internal pure returns (address maskedAddr) {
         assembly ("memory-safe") {
-            maskedAddr := or(actorId, 0xff00000000000000000000000000000000000000)
+            maskedAddr := or(id, 0xff00000000000000000000000000000000000000)
         }
     }
 

--- a/src/mocks/FVMMinerActor.sol
+++ b/src/mocks/FVMMinerActor.sol
@@ -172,8 +172,8 @@ contract FVMMinerActor {
             // (NO_DEADLINE, NO_PARTITION): sector must be absent from the sectors AMT.
             // Any sector with a known location is still in the AMT (even if terminated) — USR_NOT_FOUND.
             if (s.hasLocation) return (USR_NOT_FOUND, 0, "");
-            bool valid = requested == SectorStatus.Dead;
-            return (0, CBOR_CODEC, abi.encodePacked(valid ? uint8(0xf5) : uint8(0xf4)));
+            bool validDead = requested == SectorStatus.Dead;
+            return (0, CBOR_CODEC, abi.encodePacked(validDead ? uint8(0xf5) : uint8(0xf4)));
         } else {
             // Normal location: sector must be registered at (deadline, partition).
             if (!s.hasLocation) return (USR_NOT_FOUND, 0, "");


### PR DESCRIPTION

Fixes #18
While I think the self-documenting `actorId` names are better, I don't want this library's consumers to have to see the compilation warning.
#### Changes
* rename variables to restore shadowed declarations warning